### PR TITLE
Remove conditional in #pluck_to_hash, make it one line

### DIFF
--- a/lib/pluck_to_hash.rb
+++ b/lib/pluck_to_hash.rb
@@ -5,11 +5,7 @@ module PluckToHash
 
   module ClassMethods
   	def pluck_to_hash(keys)
-      if keys.is_a? Array
-        pluck(*keys).map{|row| Hash[*[keys, row].transpose.flatten]}
-      else
-      	pluck(*keys).map{|row| Hash[*[[keys], [row]].transpose.flatten]}
-      end
+      pluck(*keys).map{|row| Hash[*[Array(keys), Array(row)].transpose.flatten]}
     end
 
     alias_method :pluck_h, :pluck_to_hash


### PR DESCRIPTION
Hey, saw this pop up on the rails subreddit and it's something that I've definitely needed in the past.

`Array()` will always return an array, so it can be used in place of the conditional. DRYs out the code and makes it shorter. Behavior doesn't change. Cheers.
