### PR TITLE
Remove unnecessary `Array()` call

### DIFF
--- a/lib/pluck_to_hash.rb
+++ b/lib/pluck_to_hash.rb
@@ -5,7 +5,7 @@ module PluckToHash
 
   module ClassMethods
     def pluck_to_hash(*keys)
-      pluck(*keys).map{|row| Hash[Array(keys).zip(Array(row))]}
+      pluck(*keys).map{|row| Hash[keys.zip(Array(row))]}
     end
 
     alias_method :pluck_h, :pluck_to_hash


### PR DESCRIPTION
`keys` is always an instance of `Array` in this case, so we don't need to wrap it into `Array()` call there
