### PR TITLE
use-select-alias-in-hash

### DIFF
--- a/lib/pluck_to_hash.rb
+++ b/lib/pluck_to_hash.rb
@@ -5,10 +5,18 @@ module PluckToHash
 
   module ClassMethods
     def pluck_to_hash(*keys)
+      formatted_keys = keys.map do |k|
+        case k
+        when String
+          k.split(' as ')[-1].to_sym
+        when Symbol
+          k
+        end
+      end
 
       pluck(*keys).map do |row|
         row = [row] if keys.size == 1
-        Hash[keys.zip(row)]
+        Hash[formatted_keys.zip(row)]
       end
     end
 


### PR DESCRIPTION
I have added the possibility of using aliases in the SELECT statement:

``` ruby
MyModel.pluck(:id, 'my_datetime::date as my_date', 'my_datetime::time as my_time')

=> [{:id=>9, :my_date=>Sat, 25 Jul 2015, :my_time=>Sat, 25 Jul 2015},
 {:id=>5, :my_date=>Sat, 25 Jul 2015, :my_time=>Sat, 25 Jul 2015},
 {:id=>1, :my_date=>Sat, 25 Jul 2015, :my_time=>Sat, 25 Jul 2015},
 {:id=>17, :my_date=>Sat, 25 Jul 2015, :my_time=>Sat, 25 Jul 2015},
 {:id=>13, :my_date=>Sat, 25 Jul 2015, :my_time=>Sat, 25 Jul 2015}]
```

I use this feature in my project so that I can offload more work from Rails to Postgres.
Also, I have normalized all the keys passed as strings to symbols. What's your opinion?
If that seems interesting I can add some tests.
