### PR TITLE
update pluck_to_hash.rb

### DIFF
--- a/lib/pluck_to_hash.rb
+++ b/lib/pluck_to_hash.rb
@@ -5,6 +5,7 @@ module PluckToHash
 
   module ClassMethods
     def pluck_to_hash(*keys)
+      keys = column_names if keys.blank?
       formatted_keys = keys.map do |k|
         case k
         when String
@@ -14,14 +15,9 @@ module PluckToHash
         end
       end
       
-      block_given = block_given?
-      keys = column_names if keys.blank?
-
       pluck(*keys).map do |row|
         row = [row] if keys.size == 1
         HashWithIndifferentAccess[formatted_keys.zip(row)]
-        yield(value) if block_given
-        value
       end
     end
 

--- a/lib/pluck_to_hash.rb
+++ b/lib/pluck_to_hash.rb
@@ -5,19 +5,21 @@ module PluckToHash
 
   module ClassMethods
     def pluck_to_hash(*keys)
+      block_given = block_given?
       keys = column_names if keys.blank?
       formatted_keys = keys.map do |k|
         case k
-        when String
-          k.split(' as ')[-1].to_sym
-        when Symbol
-          k
+          when String
+            k.split(' as ')[-1].to_sym
+          when Symbol
+            k
         end
       end
-      
       pluck(*keys).map do |row|
         row = [row] if keys.size == 1
-        HashWithIndifferentAccess[formatted_keys.zip(row)]
+        value = HashWithIndifferentAccess[formatted_keys.zip(row)]
+        yield(value) if block_given
+        value
       end
     end
 

--- a/lib/pluck_to_hash.rb
+++ b/lib/pluck_to_hash.rb
@@ -13,10 +13,15 @@ module PluckToHash
           k
         end
       end
+      
+      block_given = block_given?
+      keys = column_names if keys.blank?
 
       pluck(*keys).map do |row|
         row = [row] if keys.size == 1
-        Hash[formatted_keys.zip(row)]
+        HashWithIndifferentAccess[formatted_keys.zip(row)]
+        yield(value) if block_given
+        value
       end
     end
 

--- a/spec/pluck_to_hash_spec.rb
+++ b/spec/pluck_to_hash_spec.rb
@@ -12,7 +12,7 @@ describe 'PluckToHash' do
 
     it 'plucks the ids of the objects to a hash correctly' do
       TestModel.all.pluck_to_hash(:id).each do |hash|
-        expect(hash.class).to eq(Hash)
+        expect(hash.class).to eq(HashWithIndifferentAccess)
         expect(hash).to have_key(:id)
       end
     end
@@ -37,7 +37,7 @@ describe 'PluckToHash' do
     context 'specifying multiple attributes' do
       it 'returns a hash with both attributes' do
         TestModel.all.pluck_to_hash(:id, :test_attribute).each do |hash|
-          expect(hash.class).to eq(Hash)
+          expect(hash.class).to eq(HashWithIndifferentAccess)
           expect(hash).to have_key(:id)
           expect(hash).to have_key(:test_attribute)
         end
@@ -56,18 +56,18 @@ describe 'PluckToHash' do
       it 'plucks the hash correctly' do
         result = TestModel.pluck_to_hash(:serialized_attribute)
         expect(result).to eq [
-          { serialized_attribute: [] },
-          { serialized_attribute: ['Zygohistomorpic', 'Prepromorphism'] },
-          { serialized_attribute: ['Comonad'] }
+          { serialized_attribute: [] }.with_indifferent_access,
+          { serialized_attribute: ['Zygohistomorpic', 'Prepromorphism'] }.with_indifferent_access,
+          { serialized_attribute: ['Comonad'] }.with_indifferent_access
         ]
       end
 
       it 'plucks a hash with multiple attributes' do
         result = TestModel.pluck_to_hash(:test_attribute, :serialized_attribute)
         expect(result).to eq [
-          { test_attribute: nil, serialized_attribute: [] },
-          { test_attribute: nil, serialized_attribute: ['Zygohistomorpic', 'Prepromorphism'] },
-          { test_attribute: nil, serialized_attribute: ['Comonad'] }
+          { test_attribute: nil, serialized_attribute: [] }.with_indifferent_access,
+          { test_attribute: nil, serialized_attribute: ['Zygohistomorpic', 'Prepromorphism'] }.with_indifferent_access,
+          { test_attribute: nil, serialized_attribute: ['Comonad'] }.with_indifferent_access
         ]
       end
     end
@@ -83,7 +83,7 @@ describe 'PluckToHash' do
 
       it 'plucks the ids of the objects to a hash correctly' do
         TestModel.all.pluck_h(:id).each do |hash|
-          expect(hash.class).to eq(Hash)
+          expect(hash.class).to eq(HashWithIndifferentAccess)
           expect(hash).to have_key(:id)
         end
       end
@@ -108,7 +108,7 @@ describe 'PluckToHash' do
       context 'specifying multiple attributes' do
         it 'returns a hash with both attributes' do
           TestModel.all.pluck_h(:id, :test_attribute).each do |hash|
-            expect(hash.class).to eq(Hash)
+            expect(hash.class).to eq(HashWithIndifferentAccess)
             expect(hash).to have_key(:id)
             expect(hash).to have_key(:test_attribute)
           end


### PR DESCRIPTION
1. User of HashWithIndifferentAccess instead of Hash
2. Support blocks Model.pluck_h(:key) do |plucked_hash| end
3. If no argument passed to pluck_h, take all the columns. Inspired from select([]) takes all columns
