### PR TITLE
ignore case for AS sql keyword on field name detection

### DIFF
--- a/lib/pluck_to_hash.rb
+++ b/lib/pluck_to_hash.rb
@@ -8,7 +8,7 @@ module PluckToHash
       formatted_keys = keys.map do |k|
         case k
         when String
-          k.split(' as ')[-1].to_sym
+          k.split(/ as /i)[-1].to_sym
         when Symbol
           k
         end

--- a/spec/pluck_to_hash_spec.rb
+++ b/spec/pluck_to_hash_spec.rb
@@ -17,6 +17,25 @@ describe 'PluckToHash' do
       end
     end
 
+    it 'pluck field with lowercase alias' do
+      TestModel.all.pluck_to_hash('id as Something').each do |hash|
+        expect(hash).to have_key(:Something)
+      end
+    end
+
+    it 'pluck field with uppercase alias' do
+      TestModel.all.pluck_to_hash('id AS otherfield').each do |hash|
+        expect(hash).to have_key(:otherfield)
+      end
+    end
+
+    it 'pluck field with mixedcase alias' do
+      TestModel.all.pluck_to_hash('id As anotherfield').each do |hash|
+        expect(hash).to have_key(:anotherfield)
+      end
+    end
+
+
     context 'the model does not have the attribute specified' do
       it 'raises an error' do
         expect do


### PR DESCRIPTION
Scenario:
if you write pluck_to_hash('sum(amount) AS amount') result will be { :'sum(amount) AS amount' => 1}
this PR fix described issue
Here is what I have {:"kiosks.location AS location"=>"Ravenswood Ave", :"payments.payment_type_id AS payment_type_id"=>3, :"sum(payments.amount) AS amount"=>#<BigDecimal:7fc0e19e73a8,'0.5E2',9(18)>}
