### PR TITLE
Better performance with Postgres

### DIFF
--- a/lib/pluck_to_hash.rb
+++ b/lib/pluck_to_hash.rb
@@ -5,19 +5,12 @@ module PluckToHash
 
   module ClassMethods
     def pluck_to_hash(*keys)
-      formatted_keys = keys.map do |k|
-        case k
-        when String
-          k.split(' as ')[-1].to_sym
-        when Symbol
-          k
-        end
-      end
-
-      pluck(*keys).map do |row|
-        row = [row] if keys.size == 1
-        Hash[formatted_keys.zip(row)]
-      end
+      # http://stackoverflow.com/questions/25331778/getting-typed-results-from-activerecord-raw-sql#answer-30948357
+      @type_map ||= PG::BasicTypeMapForResults.new(connection.raw_connection)
+      sql = select(*keys).to_sql
+      results = connection.execute(sql)
+      results.type_map = @type_map
+      results
     end
 
     alias_method :pluck_h, :pluck_to_hash


### PR DESCRIPTION
Hi! Thank you for this very useful gem.

A while ago I have forked it to improve performance, at least in my scenario with Postgres. If there is interest from someone else we could work something out to bring it to the your library.

So, my question is:
- Are you interested in this feature?
- If you are interested, do you have a suggestion about how to detect if the database is Postgres and in that case use this alternate implementation?

At least in my machine, this patch made a dramatic speed-up to the conversion (more than 10x) when serializing hundreds/thousands of records. I guess the Ruby overhead is greatly reduced using this method, and now the serialization speed depends almost exclusively on Postgres.