### PR TITLE
Replace keys_one by Array() call

### DIFF
--- a/lib/pluck_to_hash.rb
+++ b/lib/pluck_to_hash.rb
@@ -8,10 +8,9 @@ module PluckToHash
       hash_type = keys[-1].is_a?(Hash) ? keys.pop.fetch(:hash_type,HashWithIndifferentAccess) : HashWithIndifferentAccess
       block_given = block_given?
       keys, formatted_keys = format_keys(keys)
-      keys_one = keys.size == 1
 
       pluck(*keys).map do |row|
-        value = hash_type[formatted_keys.zip(keys_one ? [row] : row)]
+        value = hash_type[formatted_keys.zip(Array(row))]
         block_given ? yield(value) : value
       end
     end


### PR DESCRIPTION
(Not tested, contribution on the fly) `Array(o)` return `o` if `o` is already an `Array` and `[o]` otherwise.