### PR TITLE
When a Symbol with an "as" Alias is present, handle it correctly

### DIFF
--- a/lib/pluck_to_hash.rb
+++ b/lib/pluck_to_hash.rb
@@ -4,6 +4,9 @@ module PluckToHash
   extend ActiveSupport::Concern
 
   module ClassMethods
+
+    AS_REGEX = /\bas\b/i
+
     def pluck_to_hash(*keys)
       block_given = block_given?
       hash_type = keys[-1].is_a?(Hash) ? keys.pop.fetch(:hash_type,HashWithIndifferentAccess) : HashWithIndifferentAccess
@@ -44,13 +47,21 @@ module PluckToHash
             keys.map do |k|
               case k
               when String
-                k.split(/\bas\b/i)[-1].strip.to_sym
+                extract_as(k)
               when Symbol
-                k
+                if !(k.to_s =~ AS_REGEX).nil?
+                  extract_as(k.to_s)
+                else
+                  k
+                end
               end
             end
           ]
         end
+      end
+
+      def extract_as(input)
+        input.split(AS_REGEX)[-1].strip.to_sym
       end
 
     alias_method :pluck_h, :pluck_to_hash

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -22,6 +22,12 @@ shared_context 'essentials' do
     end
   end
 
+  it 'pluck field with symbol alias' do
+    TestModel.all.pluck_to_hash(:'id as something').each do |hash|
+      expect(hash).to have_key(:something)
+    end
+  end
+
   it 'pluck field with uppercase alias' do
     TestModel.all.pluck_to_hash('id AS otherfield').each do |hash|
       expect(hash).to have_key(:otherfield)


### PR DESCRIPTION
Fixes #20

Extract separation logic into a new function and make the regex into
a constant